### PR TITLE
hardcode `next.revalidate` option to `XataClient`

### DIFF
--- a/lib/xata.codegen.ts
+++ b/lib/xata.codegen.ts
@@ -60,6 +60,15 @@ let instance: XataClient | undefined = undefined;
 export const getXataClient = () => {
   if (instance) return instance;
 
-  instance = new XataClient();
+  instance = new XataClient({
+    fetch: (path, options) => {
+      return fetch(path, {
+        ...options,
+        next: {
+          revalidate: process.env.NODE_ENV === "development" ? 1 : 15,
+        },
+      });
+    },
+  });
   return instance;
 };


### PR DESCRIPTION
The `next.revalidate` option will override the default `cache` and force runtime to always be **static** if `revalidate` is a number or **dynamic** if `revalidate` is `false`.